### PR TITLE
fixing credentials=include without credentials. 

### DIFF
--- a/src/ButtonPanel.tsx
+++ b/src/ButtonPanel.tsx
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import React, { PureComponent } from 'react';
 import { Button, IconName, ButtonVariant } from '@grafana/ui';
 import { PanelProps } from '@grafana/data';
@@ -105,7 +104,6 @@ export class ButtonPanel extends PureComponent<Props, ButtonPanelState> {
     let fetchOpts: RequestInit = {
       method: options.method, // *GET, POST, PUT, DELETE, etc.
       mode: 'cors', // no-cors, *cors, same-origin
-      credentials: 'include', // include, *same-origin, omit
       cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
       headers: requestHeaders,
       redirect: 'follow', // manual, *follow, error
@@ -120,6 +118,7 @@ export class ButtonPanel extends PureComponent<Props, ButtonPanelState> {
     }
 
     if (options.isAuth) {
+      fetchOpts.credentials= 'include';
       requestHeaders.set('Authorization', 'Basic ' + btoa(options.username + ':' + options.password));
     }
 


### PR DESCRIPTION
Fixing credentials=include without credentials. 

`if options.isAuth is true, then fetchOpts.credentials= 'include'` 

The isomorphic-fetch import is also removed to use window.fetch (https://caniuse.com/fetch)
Dependency is present in .lock but not in package.json

fix #45


